### PR TITLE
Support for clean & safe error handling on IE 11

### DIFF
--- a/src/templates/pad.html
+++ b/src/templates/pad.html
@@ -353,6 +353,7 @@
 
         <% e.begin_block("scripts"); %>
         <script type="text/javascript">
+          var padutils = require('../static/js/pad_utils').padutils;
             // @license magnet:?xt=urn:btih:8e4f440f4c65981c5bf93c76d35135ba5064d8b7&dn=apache-2.0.txt
             (function() {
               // Display errors on page load to the user
@@ -362,7 +363,7 @@
                 var box   = document.getElementById('editorloadingbox');
                 box.innerHTML = '<p><b>An error occurred while loading the pad</b></p>'
                               + '<p><b>'+msg+'</b> '
-                              + '<small>in '+ url +' (line '+ line +')</small></p>';
+                              + '<small>in '+ padutils.escapeHTML(url) +' (line '+ line +')</small></p>';
                 // call original error handler
                 if(typeof(originalHandler) == 'function') originalHandler.call(null, arguments);
               };
@@ -400,6 +401,7 @@
 
               var plugins = require('ep_etherpad-lite/static/js/pluginfw/client_plugins');
               var hooks = require('ep_etherpad-lite/static/js/pluginfw/hooks');
+              var padutils = require('../static/js/pad_utils');
 
               plugins.baseURL = baseURL;
               plugins.update(function () {
@@ -419,7 +421,7 @@
               pad = require('ep_etherpad-lite/static/js/pad').pad;
               chat = require('ep_etherpad-lite/static/js/chat').chat;
               padeditbar = require('ep_etherpad-lite/static/js/pad_editbar').padeditbar;
-              padimpexp = require('ep_etherpad-lite/static/js/pad_impexp').padimpexp;
+              padimpexp = require('ep_etherpad-lite/static/js/pad_impexp').padimpexp
             }());
             // @license-end
         </script>


### PR DESCRIPTION
Added pad_utils sanitization for clean and safe error handling on browsers that do not encode the path of the URL.